### PR TITLE
Icon rendering fix

### DIFF
--- a/src/SecurityInspector/widget/ui/SecurityInspector.css
+++ b/src/SecurityInspector/widget/ui/SecurityInspector.css
@@ -1,13 +1,12 @@
 .squareBox{
-  position: absolute;
-  right: 0;
-  top: 300px;
-  margin-top: -100px;
+  position: fixed;
+  right: 0.5em;
+  bottom: 2em;
   height: 85px;
   width: 70px;
   color: white;
   border: 2px solid #000;
-  z-index: 999999999;
+  z-index: 9999;
 }
 .TableWrapper{
   display: inline-block;


### PR DESCRIPTION
Changed positioning from absolute to fixed. Placed it on the bottom-right to prevent it from overlapping any other widget (e.g. Feedback widget)